### PR TITLE
Use memmap2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "lock_api"
@@ -192,13 +192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
+name = "memmap2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
- "winapi",
 ]
 
 [[package]]
@@ -307,7 +306,7 @@ dependencies = [
  "inplace-vec-builder",
  "log",
  "maplit",
- "memmap",
+ "memmap2",
  "obey",
  "parking_lot",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ inplace-vec-builder = "0.1.1"
 visibility = "0.0.1"
 fnv = { version = "1.0.7", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
-memmap = { version = "0.7.0", optional = true }
+memmap2 = { version = "0.9.4", optional = true }
 
 [features]
 custom-store = []
 mem-store = ["custom-store", "parking_lot"]
-paged-file-store = ["custom-store", "memmap", "parking_lot", "fnv"]
+paged-file-store = ["custom-store", "memmap2", "parking_lot", "fnv"]
 default = ["custom-store", "mem-store", "paged-file-store"]
 
 [dev-dependencies]

--- a/src/store/blob_store.rs
+++ b/src/store/blob_store.rs
@@ -323,7 +323,7 @@ mod tests {
 
     #[test]
     fn zero_copy_mmap() -> anyhow::Result<()> {
-        use memmap::MmapOptions;
+        use memmap2::MmapOptions;
         use std::{io::Write, sync::Arc};
         // create a large file
         let mut large_file = tempfile().unwrap();

--- a/src/store/paged_file_store.rs
+++ b/src/store/paged_file_store.rs
@@ -1,5 +1,5 @@
 use fnv::FnvHashMap;
-use memmap::{Mmap, MmapOptions};
+use memmap2::{Mmap, MmapOptions};
 use parking_lot::Mutex;
 
 use std::{


### PR DESCRIPTION
The dependency `memmap` is flagged as unmaintained by `cargo audit` (https://rustsec.org/advisories/RUSTSEC-2020-0077.html).
A maintained fork exists (https://crates.io/crates/memmap2) and there are other projects that made the migration to the new crate (https://github.com/microsoft/onefuzz/pull/428) that seems to be a drop-in replacement.